### PR TITLE
Add a minimal polyfill for MS-Edge support

### DIFF
--- a/source/WebApp/js/app.js
+++ b/source/WebApp/js/app.js
@@ -3,6 +3,7 @@ import getBranchesAsync from './server/get-branches-async.js';
 
 import state from './state/index.js';
 import uiAsync from './ui/index.js';
+import 'core-js/web/dom-collections';
 
 /* eslint-disable no-invalid-this */
 

--- a/source/WebApp/package.json
+++ b/source/WebApp/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "codemirror": "^5.19.0",
+    "core-js": "^2.4.1",
     "dateformat": "^1.0.12",
     "lz-string": "^1.4.4",
     "mirrorsharp": "^0.9.0-pre-20170515",


### PR DESCRIPTION
Only iterable DOM collections were missing for Creators Update version of edge.

![2017-05-16 22_14_57-sharplab and 1 more page - microsoft edge](https://cloud.githubusercontent.com/assets/131878/26126226/1ae16eb0-3a85-11e7-8e63-c8763aa0cc5a.png)
