### PR TITLE
Make SVG icons more crisp

### DIFF
--- a/source/WebApp/svg/ast-node.svg
+++ b/source/WebApp/svg/ast-node.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">  
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0.5 0.5 20 20">
   <rect x="4" y="4"  width="12" height="4" fill="#4684ee" stroke="#f6f6f6" stroke-width="1" />
   <rect x="4" y="8"  width="12" height="4" fill="#4684ee" stroke="#f6f6f6" stroke-width="1" />
   <rect x="4" y="12" width="12" height="4" fill="#4684ee" stroke="#f6f6f6" stroke-width="1" />

--- a/source/WebApp/svg/ast-token.svg
+++ b/source/WebApp/svg/ast-token.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0.5 0.5 20 20">
   <rect x="4" y="8"  width="12" height="4" fill="#eeb046" stroke="#f6f6f6" stroke-width="1" />
 </svg>

--- a/source/WebApp/svg/ast-trivia.svg
+++ b/source/WebApp/svg/ast-trivia.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-  <path d="M5.5,7.1 v3.9 h9 v-3.9" stroke="#f6f6f6" stroke-width="4" fill="none" />  
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0.5 0.5 20 20">
+  <path d="M5.5,7.1 v3.9 h9 v-3.9" stroke="#f6f6f6" stroke-width="4" fill="none" />
   <path d="M5.5,8 v3 h9 v-3" stroke="#666" stroke-width="2" fill="none" />
 </svg>

--- a/source/WebApp/svg/ast-value.svg
+++ b/source/WebApp/svg/ast-value.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0.5 0.5 20 20">
   <rect x="8"  y="8"  width="4" height="4" fill="#eeb046" stroke="#f6f6f6" stroke-width="1" />
 </svg>

--- a/source/WebApp/svg/tree-minus.svg
+++ b/source/WebApp/svg/tree-minus.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0.5 0.5 20 20">
   <path d="M6,10 h8" stroke="#000" stroke-width="1" fill="none" />
 </svg>

--- a/source/WebApp/svg/tree-plus.svg
+++ b/source/WebApp/svg/tree-plus.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0.5 0.5 20 20">
   <path d="M6,10 h8 h-4 v-4 v8" stroke="#000" stroke-width="1" fill="none" />
 </svg>


### PR DESCRIPTION
# Before

![screen shot 2017-06-01 at 2 11 35 pm](https://cloud.githubusercontent.com/assets/573215/26701177/edeb4ab4-46d4-11e7-84d4-b7292876d14f.png)

# After

![screen shot 2017-06-01 at 2 14 44 pm](https://cloud.githubusercontent.com/assets/573215/26701182/f20de7c8-46d4-11e7-934a-c041576a1449.png)
