### PR TITLE
Fix test on non-English culture

### DIFF
--- a/source/Tests/ExecutionTests.cs
+++ b/source/Tests/ExecutionTests.cs
@@ -195,9 +195,9 @@ namespace SharpLab.Tests {
         [InlineData("Console.WriteLine(\"abc\");", "abc{newline}")]
         [InlineData("Console.Write('a');", "a")]
         [InlineData("Console.Write(3);", "3")]
-        [InlineData("Console.Write(3.1);", "3.1")]
+        [InlineData("Console.Write(3.1);", 3.1)]
         [InlineData("Console.Write(new object());", "System.Object")]
-        public async Task SlowUpdate_IncludesConsoleInOutput(string code, string expectedOutput) {
+        public async Task SlowUpdate_IncludesConsoleInOutput(string code, object expectedOutput) {
             var driver = await NewTestDriverAsync(@"
                 using System;
                 public static class Program {
@@ -209,7 +209,7 @@ namespace SharpLab.Tests {
 
             AssertIsSuccess(result);
             Assert.Equal(
-                expectedOutput.Replace("{newline}", Environment.NewLine),
+                expectedOutput.ToString().Replace("{newline}", Environment.NewLine),
                 result.ExtensionResult.GetOutputAsString()
             );
         }


### PR DESCRIPTION
This test failed on my computer with the cs-CZ culture, which uses `,` as decimal separator:

```
Test Name:	SharpLab.Tests.ExecutionTests.SlowUpdate_IncludesConsoleInOutput(code: "Console.Write(3.1);", expectedOutput: "3.1")
Test FullName:	SharpLab.Tests.ExecutionTests.SlowUpdate_IncludesConsoleInOutput
Test Source:	E:\Users\Svick\git\SharpLab\source\Tests\ExecutionTests.cs : line 200
Test Outcome:	Failed
Test Duration:	0:00:00,74

Result StackTrace:	
at SharpLab.Tests.ExecutionTests.<SlowUpdate_IncludesConsoleInOutput>d__9.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
Result Message:	
Assert.Equal() Failure
           ↓ (pos 1)
Expected: 3.1
Actual:   3,1
           ↑ (pos 1)
```

This PR is one way to fix it.