### PR TITLE
Add "demos*" to the list of branches to build

### DIFF
--- a/Build.config.json
+++ b/Build.config.json
@@ -3,7 +3,7 @@
     {
       "Name":    "dotnet",
       "Url":     "https://github.com/dotnet/roslyn.git",
-      "Include": "^master$|^features"
+      "Include": "^master$|^features|^demos"
     }
   ]
 }


### PR DESCRIPTION
Roslyn is adding a new pattern where you can make branches starting with "demos/" for things
that aren't ship-quality, but we want to share out for people to try. It would be great if we could
try them on sharplab as well. 😄