### PR TITLE
Decompile as though using C# 1.0

### DIFF
--- a/source/Server/Decompilation/CSharpDecompiler.cs
+++ b/source/Server/Decompilation/CSharpDecompiler.cs
@@ -9,18 +9,9 @@ using SharpLab.Server.Decompilation.Internal;
 namespace SharpLab.Server.Decompilation {
     public class CSharpDecompiler : IDecompiler {
         private static readonly CSharpFormattingOptions FormattingOptions = CreateFormattingOptions();
-        private static readonly DecompilerSettings DecompilerSettings = new DecompilerSettings {
-            AnonymousMethods = false,
-            AnonymousTypes = false,
-            YieldReturn = false,
-            AsyncAwait = false,
-            AutomaticProperties = false,
-            ExpressionTrees = false,
+        private static readonly DecompilerSettings DecompilerSettings = new DecompilerSettings(ICSharpCode.Decompiler.CSharp.LanguageVersion.CSharp1) {
             ArrayInitializers = false,
-            ObjectOrCollectionInitializers = false,
             UsingStatement = false,
-            LiftNullables = false,
-            NullPropagation = false,
             DecimalConstants = false,
             AutomaticEvents = false
         };

--- a/source/Tests/DecompilationTests.cs
+++ b/source/Tests/DecompilationTests.cs
@@ -64,6 +64,7 @@ namespace SharpLab.Tests {
         [InlineData("Preprocessor.IfDebug.vb2cs")] // https://github.com/ashmind/SharpLab/issues/161
         [InlineData("FSharp.Preprocessor.IfDebug.fs2cs")] // https://github.com/ashmind/SharpLab/issues/161
         [InlineData("Using.Simple.cs2cs")] // https://github.com/ashmind/SharpLab/issues/185
+        [InlineData("StringInterpolation.Simple.cs2cs")]
         public async Task SlowUpdate_ReturnsExpectedDecompiledCode_InDebug(string resourceName) {
             var data = TestCode.FromResource(resourceName);
             var driver = await NewTestDriverAsync(data, Optimize.Debug);

--- a/source/Tests/TestCode/StringInterpolation.Simple.cs2cs
+++ b/source/Tests/TestCode/StringInterpolation.Simple.cs2cs
@@ -1,0 +1,29 @@
+public class C {
+    public void M() {
+        string one = $"This {1} That";
+        string two = $"This {one} That";
+    }
+}
+
+#=>
+
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Security.Permissions;
+
+[assembly: CompilationRelaxations(8)]
+[assembly: RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.Default | DebuggableAttribute.DebuggingModes.DisableOptimizations | DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints | DebuggableAttribute.DebuggingModes.EnableEditAndContinue)]
+[assembly: SecurityPermission(SecurityAction.RequestMinimum, SkipVerification = true)]
+[assembly: AssemblyVersion("0.0.0.0")]
+[module: UnverifiableCode]
+public class C
+{
+    public void M()
+    {
+        string str = string.Format("This {0} That", 1);
+        string text = "This " + str + " That";
+    }
+}


### PR DESCRIPTION
This change tells ILSpy to use C# 1.0 semantics when decompiling code, and removes all of the options that were previously manually set. This should mean that any future new language feature in C# is automatically disabled without needing to chase down each individual properties.

Some of the properties on DecompilerOptions are not set in the constructor so I've left them in place.

I also added a test for StringInterpolation since I wrote that on the journey to this change, and figured it doesn't hurt to leave it :)

Fixes #385