### PR TITLE
Update README to remove VB as decompilation target

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Due to complexity of F#'s compiler library, some features might not be available
 
 ### Decompilation/Disassembly
 
-There are currently four targets for decompilation/disassembly:
+There are currently three targets for decompilation/disassembly:
 
 1. C#
 2. IL

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There are currently four targets for decompilation/disassembly:
 2. IL
 3. JIT Asm (Native Asm Code)
 
-Note that C#=>VB disassembly shouldn't be used to convert between languages, as the produced code is intentionally overly verbose.
+Note that VB=>C# disassembly shouldn't be used to convert between languages, as the produced code is intentionally overly verbose.
 
 ### Execution
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ Due to complexity of F#'s compiler library, some features might not be available
 There are currently four targets for decompilation/disassembly:
 
 1. C#
-2. Visual Basic
-3. IL
-4. JIT Asm (Native Asm Code)
+2. IL
+3. JIT Asm (Native Asm Code)
 
-Note that C#=>VB or VB=>C# disassembly shouldn't be used to convert between languages, as the produced code is intentionally overly verbose.
+Note that C#=>VB disassembly shouldn't be used to convert between languages, as the produced code is intentionally overly verbose.
 
 ### Execution
 


### PR DESCRIPTION
Unless I'm missing something, VB is no longer a decompilation target on sharplab.io?