### PR TITLE
Show 7 digits of commit SHA instead of just 6

### DIFF
--- a/source/WebApp/index.html
+++ b/source/WebApp/index.html
@@ -80,7 +80,7 @@
             </div>
             <div>
               Latest commit
-              <a v-bind:href="'https://github.com/dotnet/roslyn/commit/' + branch.commits[0].hash" target="_blank">{{branch.commits[0].hash.substr(0, 6)}}</a>
+              <a v-bind:href="'https://github.com/dotnet/roslyn/commit/' + branch.commits[0].hash" target="_blank">{{branch.commits[0].hash.substr(0, 7)}}</a>
               by {{branch.commits[0].author}}:
             </div>
             <div class="branch-commit-message">{{branch.commits[0].message.trim()}}</div>


### PR DESCRIPTION
The reasons for this are:

1. GitHub doesn't autoformat 6 digit SHAs, 7 digits seem to be required. E.g. `fcd072, fcd072f` shows as: "fcd072, fcd072f". So this change would make copy-pasting information from SharpLab to GitHub better.
2. Six digits are not enough to unambiguously identify some commits on the Roslyn repo.

    E.g. 6 digits are enough for dotnet/roslyn@a35da5a17c0fb5b691204637982a6559fcbd4afb (see that https://github.com/dotnet/roslyn/commit/a35da5 works). But for dotnet/roslyn@9d293eaa6245d9726e7d0b5a15c5c8da3a890adb, 7 digits are required (see that https://github.com/dotnet/roslyn/commit/9d293e is 404).

An argument could be made that 7 digits are still not enough (e.g. `git rev-parse --short` defaults to 10 digits for my clone of the Roslyn repo), but if it's enough for GitHub, it's enough for me.