### PR TITLE
Add some tokens to asm grammar builtins

### DIFF
--- a/source/WebApp/components/internal/codemirror/mode-asm.js
+++ b/source/WebApp/components/internal/codemirror/mode-asm.js
@@ -22,10 +22,10 @@
         "daa", "das", "dec", "div",
         "enter", "esc",
         "hlt",
-        "idiv", "imul", "in", "inc", "ins", "insd", "int", "into", "invd", "invlpg", "iret", "iret[df]",
+        "idiv", "imul", "in", "inc", "ins", "insd", "int", "int[13o]", "invd", "invlpg", "iret", "iret[df]",
         conditional("j"), "jecxz", "jcxz", "jmp",
         "lahf", "lar", "lds", "lea", "leave", "les", "l[gil]dt", "lfs", "lgs", "lmsw", "loadall", "lock", "lods[bdw]", "loop", "loop[dw]?", "loopn?[ez][dw]?", "lsl", "lss", "ltr",
-        "mov", "movs[bdw]", "mov[sz]x", "mul",
+        "mov", "movs[bdw]", "mov[sz]x", "movsxd", "mul",
         "neg", "nop", "not",
         "or", "out", "outsd?",
         "pop", "pop[af]d?", "push", "push[af]d?",
@@ -34,8 +34,9 @@
         "test",
         "ud2",
         "verr", "verw",
+        "vmovdqu", "vmovdqu8", "vmovdqu16", "vmovdqu32", "vxorps",
         "wait", "wbinvd", "wrmsr",
-        "xadd", "xchg", "xlat", "xor"
+        "xadd", "xchg", "xlat", "xor", "xorps"
       ].join("|") + ")(?:$|\\s)")
     };
 


### PR DESCRIPTION
I found syntax highlighting from some missing symbols while inspecting [this code](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIAYACY8lAbhvqfIDoAlGAGYAbGGAwBLCADt2tRsz4BXKRPwxuASRUwoEAA4BlHQDdxYGLlmcFvZavUBhCPj3iRUI1FPnLHeTwARcWwAcykIXAkwX2oaAHoAKhoGBIZ+ENhcXEkpBgwLDFwGAWg8gAsYBnxxBBgAEzh8CDrKmFqwRQlpbmTU21yAd3EMMoY4OHFtKD0AXgArYZmAKWGHITxcXriaGkioRTEGAEEDDH3DgG8aAEhiAGYGSYxH2QBfHeo9g+eAcVPzjAAHgAKgA+BhXai3B5PF40d6xWikBhafLTNYbGiQ64AbQAsjARs0NC4hEcMGdxMBOpUABQEol1El6IQAeT0XSkuG4ADkIFohJNJiEAJQAXRu9y4SCYKAYMBUUAAngB9YgoFWMWkiiE3BE3fGEsrE0nkynU/IMelGk0s9mc7l8gVCqSiiVQqXMGWwhVnVVPFWw2mw8Q67G3ADsjwYAGoGORZNd9VDDYzmWSKVAqTSrQzjUzSfaco7+VJBVJheLJTCVPLFf6VCqRuJcIHa8Ha6HdVDI9G4wm9R9cXnbRnzTnrWnCxzi7zS+XK+7odKuIxfcq1eQ6JutcxGLhyGhVwxcKQwzdewfYyfSInk8ObQWWWasxa6SOn2yZ9IS86K66qw9B4vWOf5vjrP0VS+MQoLOcDaROODDiEc8e2IKMhDvIdU3zdMX2zS1J1w6cHTnP9F2rFcABkWyBPdwXXVUQkmSIVWYrlnlpGjIkBeiGBQ7trl7TDB0RB8p2fTMCPfR90yLH8yLLF03UokC/iQuitwY+s2JYjBdI4lVjAwJU9DpdSAV4rT+NQoT0P4rCxJw0d8LfXNZJI2cnSU/8VKAld1Qgjd1RVYAlVgAQ204iLHk7WzrnEBgZj7eNHIND88KktyiNHeSuUUhcAKXT1yG9WtGJVAAOKKVWwKAQiKDtnnEQ9Yua0gjxDO5Os7dA2seABWHrmqQYbHgjMbxEq+L7Ja69xGRONxAeJa5SWgb5plJaoyWyq0pTDLTSyidDrtb98u8wq/OXECfR0gBOGq6oaq0Q1akMOv65bJr6kMhq+0avomr7Ksm+6ZqjOalsWx4VseNbBs2+adseSr5vu/bxOIyTx0I06v1Iy7lMAm7SpRFQAAUziChsMA5KAovpq1USpqBHghuEoXvZzP1ck6PLOwn52J4rgLJu7IJaGA9DYhUdDMIzOJDI8WjAcR8GwIQAH4GGADnxH29KBbHV9+YkgmvOF3ySZKmVTmwMAAGtgSgB3KhCQlYIdx2zjdqKdD0K14uMOqGAgJKGCkGABjD4A5lETiRUTXso5j+2nZdt2rTgmAk9Eo3zb5vHjby38fIo/yQPT53XfMBgPf0yJvd98x/emZFtUE3sVgwDEsm4BuvadluYBVBZE8xnnMtxmTzdLgqRdUsnApGXQBhVNog67nu++5VeIHXzftUc5NEgYYEKiqR8ikmcoWyYZEhiEIQGE1gZsCVIpgEqJYNGBfI6gpG2EiBgO91hZCxAXbGJtpLuTnudMuV0bZizKs8RiW9wyogDrvbgFUQpajzj2LB6JwHcjwRqAhydYSZAjsQvQOCKoBiDOQQhQlxACCtDQgAhMlM8F5ewDh7CHNmYAI6p3JmiehpCg7JxoclMAuCdIBmbK2ZhrCEocNpNw3hIp+H2VvBeYRJ5aFTCkRsRRkE9w7itAAIiODYo8NiABCNj1HsKtEUHhDA7EuN0T2Xsdxk5GLwBpMR0dQKhM7hcaMyVyAMFeEE0OISATImSnQhhOloKN0ick74bjNG5LEKQbgiUvEsL0VGNghjQ4v2SuI7imk6DgmPtUtmQhUkSOwaQixG52KsT6ZxFCVDNEvy8e0vxQlewDUSWzBqoS6nhIst8KyTSMExPjPEmZ9cskdPSd0iqAyDKsWMqZOkcyAT5KtOc74xTSmxImXZKMSAqG1hDrU1KF49nmPIaFcKggoqcMEAwN5lzaRvIYF4vh/j7IRlkRYExkiMmQWqgGZ6jVWqfW6gwPq/1AbA2msMwFnjkp3CQA83se0LxyM6SQ75D0nr1XRUeTFR4cVHjxUeUGDBwaEq0fCrxKABrkvshjVpDAmYLJjizamtI7hni2fTXZpikUbiePTRmMr6agqZl4xVwqoxbi2fUEIxkVSwGeGk5V+ydJSxlh7KOWYwCKytOQO4dxgakHwKC41przUQtiW6iM+r4yCMeQwOgk98ZF1ntA+eRNraixXIhAE8oEDDEVqcq0ybwK4A5jEJM2Eo3HWLvAoW5EipLxlA0lZDE036QGVaatfEBLhnsiJLmhbjbRrgbGhBC8E2VoYEssQNbU3psOScsyVph2NPBC2i8bbI1duLTG3Kfb40V1JjKQKbR01hRinyjhIZ4qJRjLEpdhcV09rXWW8uFbK7LzlPvQ+CAMEXmfZHcJABRBA5hzoyPzgdZdM9r2fjjVbTdtsGDV0znXQeTdh611HuPN9aEoxfP7vBjAzckNt0Di0jtTki0gZymB9dEH71bug9hjOSH66ewQz7XD48O4cww9yLDOG/ZPADqxi90Du2kbkuR8t10oN7lXCqAQuh8B4aDjccMYAyihxxGKXWigOGSoYEplTW4xTJxKGzJq6yI3RkBOpgQ3AqIKhCCMVgjwYwxnJdSDhOJxBqeSrSHTUAdS0iajqAA5NgAL811H2XERJ2kLmjx0CPFuVhCJkwAGJ3EqhVHiVkTiNBUS/WljgyI8Q1HqMCAomxqBJZgEIXAMB8vn1KzQCrUg6jsMgYiQdsJ8isW3OgqJF44hxHPmUe+dQIDwuwLkHj0w4CghQ77LkwwcgLqjGAulfoAOEfa7WTr+lut1tQ0JYJWSwkx2zYcKJ6zyAJLFYUjAHSVv913fpSddIbugpu7c/18Zg2huuEYhtWmm3WQIwd0OAy7urH2XWo5nEBmgobV4sHwaDFCNB0drTM7R3ncSrEzZYrrlFIjvdshUOJ0mSnbSfHGA4c7JKZ98p0KoyBOu/+C1HyexE9wVD/dQLD2vxZ29lnn2oWTPslUtD4bMZQY6wUTUTYyhr329cfrg2FfjdTX+zkxQZMMHHgA7TzQYBHjANgDASnHjNQm6Y819R9ctHfcqLu1wOfPo3q+4HSZtMm7N+GXsEaLwIjDaG+8Uutsy+3C7pTbhAG9Z7Gtn37HuAu6Puo14nvTejB9/ZP3PYA8CMl2TYAEAIAvwEJMTWQhVTG+fvUWQg7ApV6EFJsvz8lSK7j/w538uD6u/W0JVPpepDl9bz7gfQ+VQN5t8lHOycA/B5Qf1bbsuYBlFY13UfLfx/l8n8UTW1Xa89mVxfVXuQ2ga5yFr5wOvhh68gC0I8bRRA5nXxX2KbUA7W8AbfmrseHc+4b03wfFvXvD3Y3dPR3LPGfC8dxWkLhZ/SvLfOoJHZOeyIPIcEPZ4RfbcRjJsJDRqeKfrPrAbH4QkV+E8GjJjLOQzPnN/KbGbYYabSbQOBvMg72Qgi8GDOjSIQnCHcxTjRDP2FjdbMVaTbANQRgZKSIbgYgjAAAMVdjUCtDoHUSMRELUDiQkIwCkMJDkNELpBYS2VUJgA6UkOkJ0IUNpHlWEPkJgAeA0K0NkOsKtDuGUNDkMLlDsNMMcNpBQEISgM0UMLoHsI/CDl5F0M+xsT4IoNbkYNcQqTZz8KtEMJ4GkOCO1FCIUK8QiIY3IJHjHmGFiIZwYGRwSNpEMOKRSMfBCJ5DCMyMiNyMYNIAKJF0Z33zYX8OsLuCCMqLSOqIyOSiyOyS41bhYyaLDTFxKLcK6MZCqJqP6MwKHkdhwLdlwFGKmWQKjGzwLTEmVxkObxf1P2lk1yfhfm/nKDXlyGk0vxURYKdgYBABoMDmmyv2eCeOXzGHBEYJuEPwKHKBNwYAGEqD0F0D0FCBN0qBGEqDgPV0OPPwgGMB0HKEqF1xt0MLKyo2ly6wAOTy7kL2L092rzqAAKHwjgEF3xgGTnb38UpMmSdx4P7iTzd3UTDSZ38X7z2OH34WuAn0JKhKn32HJM5I/XER/TP2kFsS/UaKZNz1T1ALN1pBFJhOkHig0StC4W5KJJb3JTzziM2K2LDWRy2M2wwLDx3DEFKBjzsi3GMWSg5ysUuNk0YOAPsiKBmH6OwGADABaAEBCCGzmBsQYB1kYHuNQOoARCAA==) and added them to the list for the PR.

@ashmind, I think we could add all 888 unique instructions collected from three supported architectures by .NET Core for sharplab.io website:

```sh
#!/usr/bin/env sh

for filename in arm arm64 xarch; do
  # 1. curl: fetch from source for pipe
  # 2. grep: filter lines starts with INS
  # 3. awk: extract column #2 from looks-like-csv data lines and strip whitespace and quotes
  # 4. grep: omit lines with any uppercase letters
  # 5. sort: get sorted and distinct list of token

  curl -sSL https://raw.githubusercontent.com/dotnet/runtime/master/src/coreclr/src/jit/instrs${filename}.h |
  grep "^INS" |
  awk -F "\"*,\"*" '{gsub("\"|^ *|  *$", "", $2); print $2}' |
  grep -v '[[:upper:]]' |
  sort -u
done | sort -u > allSymbols.txt
```

if it makes sense, should we just append these values for the existing list?

@tannergooding, @janvorli could you please confirm if there are more instructions in other places of dotnet/runtime repo, which `allSymbols.txt` could be missing?

Thanks!