### PR TITLE
Change roslyn master to main

### DIFF
--- a/#scripts/roslyn-branches/generateGitHubRunMatrix.ts
+++ b/#scripts/roslyn-branches/generateGitHubRunMatrix.ts
@@ -27,7 +27,7 @@ console.log(chalk.white('Writing matrix...'));
 const matrix = {
     include: branches.map(branch => ({
         branch,
-        optional: (branch !== 'master')
+        optional: (branch !== 'main')
     }))
 };
 

--- a/#scripts/roslyn-branches/steps/updateInBranchesJson.ts
+++ b/#scripts/roslyn-branches/steps/updateInBranchesJson.ts
@@ -6,7 +6,7 @@ import { BlobServiceClient, BlockBlobClient } from '@azure/storage-blob';
 import useAzure from './useAzure';
 import { getAzureCredentialsForAudience } from './getAzureCredentials';
 
-const languageFeatureMapUrl = 'https://raw.githubusercontent.com/dotnet/roslyn/master/docs/Language%20Feature%20Status.md';
+const languageFeatureMapUrl = 'https://raw.githubusercontent.com/dotnet/roslyn/main/docs/Language%20Feature%20Status.md';
 const branchesJsonFileName = 'branches.json';
 
 async function getRoslynBranchFeatureMap(buildRoot: string) {

--- a/.roslyn-branches.json
+++ b/.roslyn-branches.json
@@ -1,3 +1,3 @@
 {
-  "include": "^master$|^features/|^demos/"
+  "include": "^main$|^features/|^demos/"
 }

--- a/source/WebApp/components/app-select-branch.ts
+++ b/source/WebApp/components/app-select-branch.ts
@@ -100,9 +100,9 @@ function groupSortOrder(a: BranchGroup, b: BranchGroup) {
 }
 
 function branchSortOrder(a: Branch, b: Branch) {
-    // master always goes first
-    if (a.name === 'master') return -1;
-    if (b.name === 'master') return +1;
+    // main always goes first
+    if (a.name === 'main') return -1;
+    if (b.name === 'main') return +1;
 
     // if this has a language, sort by language first, with newer lang versions on top
     if (a.feature) {

--- a/source/WebApp/tests/rendering/data/branch.ts
+++ b/source/WebApp/tests/rendering/data/branch.ts
@@ -1,9 +1,9 @@
 export const branch = {
-    id: 'master',
-    name: 'master',
+    id: 'main',
+    name: 'main',
     group: 'Roslyn branches',
     kind: 'roslyn',
-    url: 'https://sl-b-dotnet-master.azurewebsites.net',
+    url: 'https://sl-b-dotnet-main.azurewebsites.net',
     commits: [{
         date: new Date('2020-05-22T18:57:31Z'),
         message: 'Merge pull request #44520 from sharwell/increase-timeouts\n\nIncrease timeouts to account for slower build machines',

--- a/source/WebApp/tests/state.url.tests.ts
+++ b/source/WebApp/tests/state.url.tests.ts
@@ -14,7 +14,7 @@ describe('legacy load', () => {
 
 describe('v2', () => {
     for (const [name, value] of ([
-        ['branchId', 'master'],
+        ['branchId', 'main'],
         ...Object.values(languages).map(l => ['language', l]),
         ...Object.values(targets).map(t => ['target', t]),
         ['release', true],


### PR DESCRIPTION
Roslyn has just renamed its master branch to main in dotnet/roslyn#51646. So I think for SharpLab to continue consuming new compilers it's necessary to change the branch name here.