### PR TITLE
Enhance asm syntax highlighting

### DIFF
--- a/source/WebApp/components/internal/codemirror/mode-asm.ts
+++ b/source/WebApp/components/internal/codemirror/mode-asm.ts
@@ -7,6 +7,12 @@ CodeMirror.defineMode('asm', () => {
     const grammar = {
         builtin: instructionsRegex
     };
+    const specifiers = [ 'byte', 'dword', 'ptr', 'qword', 'short', 'tbyte', 'word' ];
+    const registers = [ 'ah', 'al', 'ax', 'bh', 'bl', 'bp', 'bpl', 'bx', 'ch', 'cl', 'cx', 'dh', 'di', 'dil',
+        'dl', 'dx', 'eax', 'ebp', 'ebx', 'ecx', 'edi', 'edx', 'esi', 'esp', 'rax', 'rbp', 'rbx', 'rcx', 'rdi',
+        'rdx', 'rsi', 'rsp', 'r8', 'r9', 'r10', 'r11', 'r12', 'r13', 'r14', 'r15', 'r8b', 'r9b', 'r10b', 'r11b',
+        'r13b', 'r14b', 'r15b', 'r8d', 'r9d', 'r10d', 'r11d', 'r12d', 'r13d', 'r14d', 'r15d', 'r8w', 'r9w',
+        'r10w', 'r11w', 'r12w', 'r13w', 'r14w', 'r15w' ];
 
     return {
         startState() {
@@ -14,7 +20,7 @@ CodeMirror.defineMode('asm', () => {
         },
 
         token(stream) {
-            if (stream.eatSpace()) {
+            if (stream.eatSpace() || stream.eat('[') || stream.eat(']')) {
                 return null;
             }
 
@@ -26,6 +32,18 @@ CodeMirror.defineMode('asm', () => {
             // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
             if (stream.match(/\w+:/)) {
                 return 'tag';
+            }
+
+            for (const index in specifiers) {
+                if (stream.match(specifiers[index], true, true)) {
+                    return 'keyword';
+                }
+            }
+
+            for (const index in registers) {
+                if (stream.match(registers[index], true, true)) {
+                    return 'type';
+                }
             }
 
             for (const key in grammar) {

--- a/source/WebApp/scripts.ts
+++ b/source/WebApp/scripts.ts
@@ -77,7 +77,7 @@ const tsAsmRegex = task('asm', async () => {
     // read list file as array of lines
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const listContents  = ((await jetpack.readAsync(asmSourcePath))!)
-        .split('\n');
+        .split(/\r?\n/);
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     const regexPattern: string = regexCombiner(listContents).toString();


### PR DESCRIPTION
|  Before | After |
| --- | --- |
| <img width="214" alt="image" src="https://user-images.githubusercontent.com/3840695/130428493-9c670260-e245-44cf-9dea-5237103c56c5.png"> | <img width="256" alt="image" src="https://user-images.githubusercontent.com/3840695/130428210-b0973772-8a28-45d0-9df6-ddc6e41c1c0c.png"> |

(codegen is different due to different clr versions on cloud vs. localhost, but that's unrelated)