### PR TITLE
Initial IL support using Mobius.ILasm

### DIFF
--- a/source/Server/Common/CommonModule.cs
+++ b/source/Server/Common/CommonModule.cs
@@ -43,6 +43,10 @@ namespace SharpLab.Server.Common {
                    .As<ILanguageAdapter>()
                    .SingleInstance();
 
+            builder.RegisterType<ILAdapter>()
+                .As<ILanguageAdapter>()
+                .SingleInstance();
+
             RegisterConfiguration(builder);
         }
 

--- a/source/Server/Common/Languages/ILAdapter.cs
+++ b/source/Server/Common/Languages/ILAdapter.cs
@@ -1,0 +1,37 @@
+using System.Collections.Immutable;
+using JetBrains.Annotations;
+using MirrorSharp;
+using MirrorSharp.Advanced;
+using SharpLab.Server.Common.Internal;
+
+namespace SharpLab.Server.Common.Languages {
+    [UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+    public class ILAdapter : ILanguageAdapter {
+        private readonly AssemblyReferenceDiscoveryTaskSource _referencedAssembliesTaskSource = new AssemblyReferenceDiscoveryTaskSource();
+
+        public string LanguageName => "IL";
+        public void SlowSetup(MirrorSharpOptions options) {
+            options.EnableIL(o => {
+
+            });
+        }
+
+        public void SetOptimize(IWorkSession session, string optimize) {
+            
+        }
+
+        public void SetOptionsForTarget(IWorkSession session, string target) {
+            
+        }
+
+        public ImmutableArray<int> GetMethodParameterLines(IWorkSession session, int lineInMethod, int columnInMethod) {
+            return ImmutableArray<int>.Empty; // not supported yet
+        }
+
+        public ImmutableArray<string?> GetCallArgumentIdentifiers(IWorkSession session, int callStartLine, int callStartColumn) {
+            return ImmutableArray<string?>.Empty; // not supported yet
+        }
+
+        public AssemblyReferenceDiscoveryTask AssemblyReferenceDiscoveryTask => _referencedAssembliesTaskSource.Task;
+    }
+}

--- a/source/Server/Common/PreCachedAssemblyResolver.cs
+++ b/source/Server/Common/PreCachedAssemblyResolver.cs
@@ -35,6 +35,8 @@ namespace SharpLab.Server.Common {
                     return null;
                 if (reference.Name == "System.Threading.AccessControl")
                     return null;
+                if (reference.Name == "mscorlib")
+                    return null;
 
                 throw new Exception($"Assembly {reference.Name} was not found in cache.");
             }

--- a/source/Server/Compilation/Compiler.cs
+++ b/source/Server/Compilation/Compiler.cs
@@ -10,6 +10,10 @@ using Microsoft.FSharp.Collections;
 using Microsoft.FSharp.Control;
 using MirrorSharp.Advanced;
 using MirrorSharp.FSharp.Advanced;
+using MirrorSharp.IL.Advanced;
+using Mobius.ILasm.Core;
+using Mobius.ILasm.interfaces;
+using Location = Mono.ILASM.Location;
 
 namespace SharpLab.Server.Compilation {
     public class Compiler : ICompiler {
@@ -18,25 +22,38 @@ namespace SharpLab.Server.Compilation {
             debugInformationFormat: DebugInformationFormat.PortablePdb
         );
 
-        public async Task<(bool assembly, bool symbols)> TryCompileToStreamAsync(MemoryStream assemblyStream, MemoryStream? symbolStream, IWorkSession session, IList<Diagnostic> diagnostics, CancellationToken cancellationToken) {
+        public async Task<(bool assembly, bool symbols)> TryCompileToStreamAsync(MemoryStream assemblyStream,
+            MemoryStream? symbolStream, IWorkSession session, IList<Diagnostic> diagnostics,
+            CancellationToken cancellationToken) {
             if (session.IsFSharp()) {
-                var compiled = await TryCompileFSharpToStreamAsync(assemblyStream, session, diagnostics, cancellationToken).ConfigureAwait(false);
+                var compiled =
+                    await TryCompileFSharpToStreamAsync(assemblyStream, session, diagnostics, cancellationToken)
+                        .ConfigureAwait(false);
                 return (compiled, false);
             }
 
-            #warning TODO: Revisit after https://github.com/dotnet/docs/issues/14784
-            var compilation = (await session.Roslyn.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false))!;
+            if (session.IsIL()) {
+                var compiled = TryCompileILToStreamAsync(assemblyStream, session, diagnostics, cancellationToken);
+                return (compiled, false);
+            }
+
+#warning TODO: Revisit after https: //github.com/dotnet/docs/issues/14784
+            var compilation =
+                (await session.Roslyn.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false))!;
             var emitResult = compilation.Emit(assemblyStream, pdbStream: symbolStream, options: RoslynEmitOptions);
             if (!emitResult.Success) {
                 foreach (var diagnostic in emitResult.Diagnostics) {
                     diagnostics.Add(diagnostic);
                 }
+
                 return (false, false);
             }
+
             return (true, true);
         }
 
-        private async Task<bool> TryCompileFSharpToStreamAsync(MemoryStream assemblyStream, IWorkSession session, IList<Diagnostic> diagnostics, CancellationToken cancellationToken) {
+        private async Task<bool> TryCompileFSharpToStreamAsync(MemoryStream assemblyStream, IWorkSession session,
+            IList<Diagnostic> diagnostics, CancellationToken cancellationToken) {
             var fsharp = session.FSharp();
 
             // GetLastParseResults are guaranteed to be available here as MirrorSharp's SlowUpdate does the parse
@@ -47,7 +64,7 @@ namespace SharpLab.Server.Compilation {
                     "_", virtualAssemblyFile.Name,
                     fsharp.AssemblyReferencePathsAsFSharpList,
                     pdbFile: null,
-                    executable: false,//fsharp.ProjectOptions.OtherOptions.Contains("--target:exe"),
+                    executable: false, //fsharp.ProjectOptions.OtherOptions.Contains("--target:exe"),
                     noframework: true,
                     userOpName: null
                 ), null, cancellationToken).ConfigureAwait(false);
@@ -56,8 +73,37 @@ namespace SharpLab.Server.Compilation {
                     if (diagnostic.Severity.Tag == FSharpDiagnosticSeverity.Tags.Error)
                         diagnostics.Add(fsharp.ConvertToDiagnostic(diagnostic));
                 }
+
                 return virtualAssemblyFile.Stream.Length > 0;
             }
+        }
+
+        private bool TryCompileILToStreamAsync(MemoryStream assemblyStream, IWorkSession session,
+            IList<Diagnostic> diagnostics, CancellationToken cancellationToken) {
+            var cil = session.IL();
+
+            var logger = new Logger();
+            var driver = new Driver(logger, Driver.Target.Dll, false, false, false);
+            var result = driver.Assemble(new [] {session.GetText() }, assemblyStream);
+            assemblyStream.Seek(0, SeekOrigin.Begin);
+            return result;
+        }
+    }
+
+    public class Logger : ILogger {
+        public void Info(string message) {
+        }
+
+        public void Error(string message) {
+        }
+
+        public void Error(Location location, string message) {
+        }
+
+        public void Warning(string message) {
+        }
+
+        public void Warning(Location location, string message) {
         }
     }
 }

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
@@ -43,9 +43,11 @@
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.226801" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="MirrorSharp.AspNetCore" Version="3.0.3" />
-    <PackageReference Include="MirrorSharp.Common" Version="2.2.7" />
+    <PackageReference Include="MirrorSharp.Common" Version="2.2.8" />
     <PackageReference Include="MirrorSharp.FSharp" Version="0.22.0" />
+    <PackageReference Include="MirrorSharp.IL" Version="0.1.0" />
     <PackageReference Include="MirrorSharp.VisualBasic" Version="2.1.1" />
+    <PackageReference Include="Mobius.ILasm" Version="0.1.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
     <PackageReference Include="Octokit" Version="0.32.0" />
     <PackageReference Include="Iced" Version="1.6.0" />

--- a/source/WebApp/components/app-select-language.html
+++ b/source/WebApp/components/app-select-language.html
@@ -5,4 +5,5 @@
   <option v-bind:value="languages.csharp">C#</option>
   <option v-bind:value="languages.vb">Visual Basic</option>
   <option v-bind:value="languages.fsharp">F#</option>
+  <option v-bind:value="languages.IL">IL</option>
 </app-select>

--- a/source/WebApp/ts/helpers/languages.ts
+++ b/source/WebApp/ts/helpers/languages.ts
@@ -1,7 +1,8 @@
 ﻿export const languages = Object.freeze({
     csharp: 'C#',
     vb:     'Visual Basic',
-    fsharp: 'F#'
+    fsharp: 'F#',
+    IL:     'IL'
 } as const);
 
 export type LanguageName = typeof languages[keyof typeof languages];

--- a/source/WebApp/ts/state/handlers/defaults.ts
+++ b/source/WebApp/ts/state/handlers/defaults.ts
@@ -7,10 +7,12 @@ const code = asLookup({
     [languages.csharp]: 'using System;\r\npublic class C {\r\n    public void M() {\r\n    }\r\n}',
     [languages.vb]: 'Imports System\r\nPublic Class C\r\n    Public Sub M()\r\n    End Sub\r\nEnd Class',
     [languages.fsharp]: 'open System\r\ntype C() =\r\n    member _.M() = ()',
+    [languages.IL]: '.assembly ConsoleApp\r\n{\r\n}\r\n\r\n.class private auto ansi \'<Module>\'\r\n{\r\n}\r\n\r\n.class public auto ansi beforefieldinit C\r\nextends [System.Private.CoreLib]System.Object\r\n{\r\n   .method public hidebysig \r\n        instance void M () cil managed \r\n    {\r\n       .maxstack 8\r\n        ret\r\n    }\r\n\r\n   .method public hidebysig specialname rtspecialname \r\n        instance void .ctor () cil managed \r\n   {\r\n        .maxstack 8\r\n        ldarg.0\r\n        call instance void [System.Private.CoreLib]System.Object::.ctor()\r\n        ret\r\n    }\r\n}',
 
     [`${languages.csharp}.run`]: `${help.run.csharp}\r\nusing System;\r\n\r\nConsole.WriteLine("🌄");`,
     [`${languages.vb}.run`]: 'Imports System\r\nPublic Module Program\r\n    Public Sub Main()\r\n        Console.WriteLine("🌄")\r\n    End Sub\r\nEnd Module',
-    [`${languages.fsharp}.run`]: 'printfn "🌄"'
+    [`${languages.fsharp}.run`]: 'printfn "🌄"',
+    [`${languages.IL}.run`]: '.assembly ConsoleApp\r\n{\r\n}\r\n\r\n.class private auto ansi \'<Module>\'\r\n{\r\n}\r\n\r\n.class public auto ansi beforefieldinit C\r\nextends [System.Private.CoreLib]System.Object\r\n{\r\n   .method public hidebysig \r\n        static void Main () cil managed \r\n    {\r\n       .maxstack 8\r\n       ldstr "Hello IL!"\r\n       call void [System.Console]System.Console::WriteLine(string)\r\n        ret\r\n    }\r\n\r\n   .method public hidebysig specialname rtspecialname \r\n        instance void .ctor () cil managed \r\n   {\r\n        .maxstack 8\r\n        ldarg.0\r\n        call instance void [System.Private.CoreLib]System.Object::.ctor()\r\n        ret\r\n    }\r\n}'
 } as const);
 
 export default {


### PR DESCRIPTION
- uses https://github.com/kkokosa/Mobius.ILasm as an IL assembler
- minimum valuable set of changes, as I was not able to find easy way of make/test:
    - IL syntax highlighting for input
    - incorporate it into .NET Framework Server
    - test Debug/Release
    - IL Syntax/Explain not working
    - URL encoding the content uses C# as input

It will probably not compile because of outdated `Unbreakable` as discussed some time ago (locally I have it simply disabled).