### PR TITLE
Write .assembly header in IL output

### DIFF
--- a/source/NetFramework/Server/Decompilation/ILDecompiler.cs
+++ b/source/NetFramework/Server/Decompilation/ILDecompiler.cs
@@ -22,7 +22,7 @@ namespace SharpLab.Server.Decompilation {
             Argument.NotNull(nameof(streams), streams);
             Argument.NotNull(nameof(codeWriter), codeWriter);
 
-            using (var assemblyFile = new PEFile("", streams.AssemblyStream))
+            using (var assemblyFile = new PEFile("_", streams.AssemblyStream))
             using (var debugInfo = streams.SymbolStream != null ? _debugInfoFactory(streams.SymbolStream) : null) {
                 //#if DEBUG
                 //assembly.Write(@"d:\Temp\assembly\" + System.DateTime.Now.Ticks + "-il.dll");
@@ -33,6 +33,9 @@ namespace SharpLab.Server.Decompilation {
                     DebugInfo = debugInfo,
                     ShowSequencePoints = true
                 };
+
+                disassembler.WriteAssemblyHeader(assemblyFile);
+                output.WriteLine(); // empty line
                 disassembler.WriteModuleContents(assemblyFile);
             }
         }

--- a/source/NetFramework/Tests/TestCode/FSharp/EmptyType.fs
+++ b/source/NetFramework/Tests/TestCode/FSharp/EmptyType.fs
@@ -2,6 +2,15 @@ type Empty = class end
 
 (* il
 
+.assembly _
+{
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.FSharpInterfaceDataVersionAttribute::.ctor(int32, int32, int32) = (
+        01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00
+    )
+    .hash algorithm 0x<IGNORE> // SHA1
+    .ver 0:0:0:0
+}
+
 .class private auto ansi '<Module>'
     extends [mscorlib]System.Object
 {

--- a/source/NetFramework/Tests/TestCode/Finalizer.Exception.cs2il
+++ b/source/NetFramework/Tests/TestCode/Finalizer.Exception.cs2il
@@ -7,6 +7,34 @@ public class C {
 
 #=>
 
+.assembly _
+{
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = (
+        01 00 08 00 00 00 00 00
+    )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = (
+        01 00 01 00 54 02 16 57 72 61 70 4e 6f 6e 45 78
+        63 65 70 74 69 6f 6e 54 68 72 6f 77 73 01
+    )
+    .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = (
+        01 00 02 00 00 00 00 00
+    )
+    .permissionset reqmin = (
+        2e 01 80 84 53 79 73 74 65 6d 2e 53 65 63 75 72
+        69 74 79 2e 50 65 72 6d 69 73 73 69 6f 6e 73 2e
+        53 65 63 75 72 69 74 79 50 65 72 6d 69 73 73 69
+        6f 6e 41 74 74 72 69 62 75 74 65 2c 20 6d 73 63
+        6f 72 6c 69 62 2c 20 56 65 72 73 69 6f 6e 3d 34
+        2e 30 2e 30 2e 30 2c 20 43 75 6c 74 75 72 65 3d
+        6e 65 75 74 72 61 6c 2c 20 50 75 62 6c 69 63 4b
+        65 79 54 6f 6b 65 6e 3d 62 37 37 61 35 63 35 36
+        31 39 33 34 65 30 38 39 15 01 54 02 10 53 6b 69
+        70 56 65 72 69 66 69 63 61 74 69 6f 6e 01
+    )
+    .hash algorithm 0x<IGNORE> // SHA1
+    .ver 0:0:0:0
+}
+
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>

--- a/source/NetFramework/Tests/TestCode/Simple.cs2il
+++ b/source/NetFramework/Tests/TestCode/Simple.cs2il
@@ -3,6 +3,34 @@
 
 #=>
 
+.assembly _
+{
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = (
+        01 00 08 00 00 00 00 00
+    )
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = (
+        01 00 01 00 54 02 16 57 72 61 70 4e 6f 6e 45 78
+        63 65 70 74 69 6f 6e 54 68 72 6f 77 73 01
+    )
+    .custom instance void [mscorlib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = (
+        01 00 02 00 00 00 00 00
+    )
+    .permissionset reqmin = (
+        2e 01 80 84 53 79 73 74 65 6d 2e 53 65 63 75 72
+        69 74 79 2e 50 65 72 6d 69 73 73 69 6f 6e 73 2e
+        53 65 63 75 72 69 74 79 50 65 72 6d 69 73 73 69
+        6f 6e 41 74 74 72 69 62 75 74 65 2c 20 6d 73 63
+        6f 72 6c 69 62 2c 20 56 65 72 73 69 6f 6e 3d 34
+        2e 30 2e 30 2e 30 2c 20 43 75 6c 74 75 72 65 3d
+        6e 65 75 74 72 61 6c 2c 20 50 75 62 6c 69 63 4b
+        65 79 54 6f 6b 65 6e 3d 62 37 37 61 35 63 35 36
+        31 39 33 34 65 30 38 39 15 01 54 02 10 53 6b 69
+        70 56 65 72 69 66 69 63 61 74 69 6f 6e 01
+    )
+    .hash algorithm 0x<IGNORE> // SHA1
+    .ver 0:0:0:0
+}
+
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>

--- a/source/Server/Decompilation/ILDecompiler.cs
+++ b/source/Server/Decompilation/ILDecompiler.cs
@@ -23,13 +23,16 @@ namespace SharpLab.Server.Decompilation {
             Argument.NotNull(nameof(streams), streams);
             Argument.NotNull(nameof(codeWriter), codeWriter);
 
-            using (var assemblyFile = new PEFile("", streams.AssemblyStream))
+            using (var assemblyFile = new PEFile("_", streams.AssemblyStream))
             using (var debugInfo = streams.SymbolStream != null ? _debugInfoFactory(streams.SymbolStream) : null) {
                 var output = new PlainTextOutput(codeWriter) { IndentationString = "    " };
                 var disassembler = new ReflectionDisassembler(output, CancellationToken.None) {
                     DebugInfo = debugInfo,
                     ShowSequencePoints = true
                 };
+
+                disassembler.WriteAssemblyHeader(assemblyFile);
+                output.WriteLine(); // empty line
                 disassembler.WriteModuleContents(assemblyFile);
             }
         }

--- a/source/Tests/TestCode/FSharp/EmptyType.fs
+++ b/source/Tests/TestCode/FSharp/EmptyType.fs
@@ -2,6 +2,15 @@ type Empty = class end
 
 (* il
 
+.assembly _
+{
+    .custom instance void [FSharp.Core]Microsoft.FSharp.Core.FSharpInterfaceDataVersionAttribute::.ctor(int32, int32, int32) = (
+        01 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00
+    )
+    .hash algorithm 0x<IGNORE> // SHA1
+    .ver 0:0:0:0
+}
+
 .class private auto ansi '<Module>'
     extends [System.Runtime]System.Object
 {

--- a/source/Tests/TestCode/Finalizer.Exception.cs2il
+++ b/source/Tests/TestCode/Finalizer.Exception.cs2il
@@ -7,6 +7,35 @@ public class C {
 
 #=>
 
+.assembly _
+{
+    .custom instance void [System.Private.CoreLib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = (
+        01 00 08 00 00 00 00 00
+    )
+    .custom instance void [System.Private.CoreLib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = (
+        01 00 01 00 54 02 16 57 72 61 70 4e 6f 6e 45 78
+        63 65 70 74 69 6f 6e 54 68 72 6f 77 73 01
+    )
+    .custom instance void [System.Private.CoreLib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Private.CoreLib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = (
+        01 00 02 00 00 00 00 00
+    )
+    .permissionset reqmin = (
+        2e 01 80 92 53 79 73 74 65 6d 2e 53 65 63 75 72
+        69 74 79 2e 50 65 72 6d 69 73 73 69 6f 6e 73 2e
+        53 65 63 75 72 69 74 79 50 65 72 6d 69 73 73 69
+        6f 6e 41 74 74 72 69 62 75 74 65 2c 20 53 79 73
+        74 65 6d 2e 50 72 69 76 61 74 65 2e 43 6f 72 65
+        4c 69 62 2c 20 56 65 72 73 69 6f 6e 3d 35 2e 30
+        2e 30 2e 30 2c 20 43 75 6c 74 75 72 65 3d 6e 65
+        75 74 72 61 6c 2c 20 50 75 62 6c 69 63 4b 65 79
+        54 6f 6b 65 6e 3d 37 63 65 63 38 35 64 37 62 65
+        61 37 37 39 38 65 15 01 54 02 10 53 6b 69 70 56
+        65 72 69 66 69 63 61 74 69 6f 6e 01
+    )
+    .hash algorithm 0x<IGNORE> // SHA1
+    .ver 0:0:0:0
+}
+
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>

--- a/source/Tests/TestCode/Simple.cs2il
+++ b/source/Tests/TestCode/Simple.cs2il
@@ -3,6 +3,35 @@ public class Simple {
 
 #=>
 
+.assembly _
+{
+    .custom instance void [System.Private.CoreLib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = (
+        01 00 08 00 00 00 00 00
+    )
+    .custom instance void [System.Private.CoreLib]System.Runtime.CompilerServices.RuntimeCompatibilityAttribute::.ctor() = (
+        01 00 01 00 54 02 16 57 72 61 70 4e 6f 6e 45 78
+        63 65 70 74 69 6f 6e 54 68 72 6f 77 73 01
+    )
+    .custom instance void [System.Private.CoreLib]System.Diagnostics.DebuggableAttribute::.ctor(valuetype [System.Private.CoreLib]System.Diagnostics.DebuggableAttribute/DebuggingModes) = (
+        01 00 02 00 00 00 00 00
+    )
+    .permissionset reqmin = (
+        2e 01 80 92 53 79 73 74 65 6d 2e 53 65 63 75 72
+        69 74 79 2e 50 65 72 6d 69 73 73 69 6f 6e 73 2e
+        53 65 63 75 72 69 74 79 50 65 72 6d 69 73 73 69
+        6f 6e 41 74 74 72 69 62 75 74 65 2c 20 53 79 73
+        74 65 6d 2e 50 72 69 76 61 74 65 2e 43 6f 72 65
+        4c 69 62 2c 20 56 65 72 73 69 6f 6e 3d 35 2e 30
+        2e 30 2e 30 2c 20 43 75 6c 74 75 72 65 3d 6e 65
+        75 74 72 61 6c 2c 20 50 75 62 6c 69 63 4b 65 79
+        54 6f 6b 65 6e 3d 37 63 65 63 38 35 64 37 62 65
+        61 37 37 39 38 65 15 01 54 02 10 53 6b 69 70 56
+        65 72 69 66 69 63 61 74 69 6f 6e 01
+    )
+    .hash algorithm 0x<IGNORE> // SHA1
+    .ver 0:0:0:0
+}
+
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>


### PR DESCRIPTION
When IL code from preview window is copy-pasted into IL editor window, it requires `.assembly` header.

<del>ReflectionDisassembler writes this header for us in case it is a physical PE file: https://github.com/icsharpcode/ILSpy/blob/900d0a4b9354e76eb035daaf99aa88842792ae32/ICSharpCode.Decompiler/Disassembler/ReflectionDisassembler.cs#L1903. In our case it is a stream, so the header is skipped.</del>

Update: setting file name and calling `ReflectionDisassembler.WriteAssemblyHeader()` did the trick.