### PR TITLE
Add missing SSE/MMX x86 registers

### DIFF
--- a/source/WebApp/components/internal/codemirror/mode-asm.ts
+++ b/source/WebApp/components/internal/codemirror/mode-asm.ts
@@ -11,11 +11,14 @@ CodeMirror.defineMode('asm', () => {
 
     // In order to match longest possible register name, this array is pre-sorted using naturalSort function:
     // https://github.com/Bill4Time/javascript-natural-sort/blob/master/naturalSort.js
-    const registers = [ 'rsp', 'rsi', 'rdx', 'rdi', 'rcx', 'rbx', 'rbp', 'rax', 'r15w', 'r15d', 'r15b', 'r15',
-        'r14w', 'r14d', 'r14b', 'r14', 'r13w', 'r13d', 'r13b', 'r13', 'r12w', 'r12d', 'r12', 'r11w', 'r11d', 'r11b',
-        'r11', 'r10w', 'r10d', 'r10b', 'r10', 'r9w', 'r9d', 'r9b', 'r9', 'r8w', 'r8d', 'r8b', 'r8', 'esp', 'esi',
-        'edx', 'edi', 'ecx', 'ebx', 'ebp', 'eax', 'dx', 'dl', 'dil', 'di', 'dh', 'cx', 'cl', 'ch', 'bx', 'bpl',
-        'bp', 'bl', 'bh', 'ax', 'al', 'ah' ];
+    const registers = [ 'xmm15', 'xmm14', 'xmm13', 'xmm12', 'xmm11', 'xmm10', 'xmm9', 'xmm8', 'xmm7', 'xmm6', 'xmm5',
+        'xmm4', 'xmm3', 'xmm2', 'xmm1', 'xmm0', 'st7', 'st6', 'st5', 'st4', 'st3', 'st2', 'st1', 'st0', 'ss', 'spl', 'sp',
+        'sil', 'si', 'rsp', 'rsi', 'rip', 'rdx', 'rdi', 'rcx', 'rbx', 'rbp', 'rax', 'r15w', 'r15d', 'r15b', 'r15', 'r14w',
+        'r14d', 'r14b', 'r14', 'r13w', 'r13d', 'r13b', 'r13', 'r12w', 'r12d', 'r12b', 'r12', 'r11w', 'r11d', 'r11b', 'r11',
+        'r10w', 'r10d', 'r10b', 'r10', 'r9w', 'r9d', 'r9b', 'r9', 'r8w', 'r8d', 'r8b', 'r8', 'mm7', 'mm6', 'mm5', 'mm4',
+        'mm3', 'mm2', 'mm1', 'mm0', 'ip', 'gs', 'fs', 'fp6', 'fp5', 'fp4', 'fp3', 'fp2', 'fp1', 'fp0', 'esp', 'esi', 'es',
+        'eip', 'eflags', 'edx', 'edi', 'ecx', 'ebx', 'ebp', 'eax', 'dx', 'ds', 'dl', 'dil', 'di', 'dh', 'cx', 'cs', 'cl',
+        'ch', 'bx', 'bpl', 'bp', 'bl', 'bh', 'ax', 'al', 'ah' ];
 
     return {
         startState() {


### PR DESCRIPTION
XMM registers are not being highlighted. I have synchronized with the lists at https://opensource.apple.com/source/llvmCore/llvmCore-2118/lib/Target/X86/X86RegisterInfo.td.auto.html (which does not include phony registers added in https://github.com/llvm/llvm-project/commit/fd97494984071cbdf32432654d660b9cf4eca77a for convenience).

The updated array offsets registers that the current RyuJIT emitter uses on x86 archs: https://github.com/dotnet/runtime/blob/57bfe474518ab5b7cfe6bf7424a79ce3af9d6657/src/coreclr/jit/register.h.