### PR TITLE
Improve labels and numeric syntax highlighting

### DIFF
--- a/source/WebApp/components/internal/codemirror/mode-asm.ts
+++ b/source/WebApp/components/internal/codemirror/mode-asm.ts
@@ -26,7 +26,7 @@ CodeMirror.defineMode('asm', () => {
         },
 
         token(stream) {
-            if (stream.eatSpace() || stream.eat('[') || stream.eat(']')) {
+            if (stream.eatSpace() || stream.eat(/[[\]+-]/)) {
                 return null;
             }
 
@@ -36,7 +36,7 @@ CodeMirror.defineMode('asm', () => {
             }
 
             // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-            if (stream.match(/\w+:/)) {
+            if (stream.match(/L[0-9a-f]{4,}/)) {
                 return 'tag';
             }
 
@@ -57,6 +57,11 @@ CodeMirror.defineMode('asm', () => {
                 if (stream.match(grammar[key as keyof typeof grammar])) {
                     return key;
                 }
+            }
+
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+            if (stream.match(/(0x)?[0-9a-f]+/)) {
+                return 'string';
             }
 
             stream.match(/\S+/);


### PR DESCRIPTION
| Before | After |
|---|---|
| ![2021-10-12_329x440_scrot](https://user-images.githubusercontent.com/3840695/136866108-85dd82b5-9b87-45a1-8d83-0a09449d672f.png) | ![2021-10-12_310x408_scrot](https://user-images.githubusercontent.com/3840695/136866132-ee003733-1bd2-4e82-9541-8d5800b048e6.png) |

Notes on differences:
* colon after label on left side are not classified as `tag` anymore.
* labels on right side (after jump instructions) are now classified as `tag`.
* decimal and hexadecimal (addresses) numbers are classified as `string`.