### PR TITLE
Bracket moved to next line

### DIFF
--- a/source/WebApp/ts/state/handlers/defaults.ts
+++ b/source/WebApp/ts/state/handlers/defaults.ts
@@ -12,7 +12,7 @@ const normalize = (code: string) => {
 };
 
 const code = asLookup({
-    [languages.csharp]: 'using System;\r\npublic class C {\r\n    public void M() {\r\n    }\r\n}',
+    [languages.csharp]: 'using System;\r\npublic class C \r\n{\r\n    public void M() \r\n    {\r\n    }\r\n}',
     [languages.vb]: 'Imports System\r\nPublic Class C\r\n    Public Sub M()\r\n    End Sub\r\nEnd Class',
     [languages.fsharp]: 'open System\r\ntype C() =\r\n    member _.M() = ()',
     [languages.il]: normalize(`


### PR DESCRIPTION
Before

using System;
public class C {
    public void M() {
    }
}

After

using System;
public class C 
{
    public void M() 
    {
    }
}