### PR TITLE
[gh-320] - Allow unsafe in all modes

### DIFF
--- a/source/Server/Common/Languages/CSharpAdapter.cs
+++ b/source/Server/Common/Languages/CSharpAdapter.cs
@@ -81,6 +81,7 @@ namespace SharpLab.Server.Common.Languages {
                 }
             );
             options.CSharp.MetadataReferences = _references;
+            options.CSharp.CompilationOptions.WithAllowUnsafe(true);
 
             // ReSharper restore HeapView.ObjectAllocation.Evident
         }
@@ -102,7 +103,7 @@ namespace SharpLab.Server.Common.Languages {
             var project = session.Roslyn.Project;
             var options = ((CSharpCompilationOptions)project.CompilationOptions!);
             session.Roslyn.Project = project.WithCompilationOptions(
-                options.WithOutputKind(outputKind).WithAllowUnsafe(true)
+                options.WithOutputKind(outputKind)
             );
 
             _topLevelProgramSupport.UpdateOutputKind(session);

--- a/source/Server/Common/Languages/CSharpAdapter.cs
+++ b/source/Server/Common/Languages/CSharpAdapter.cs
@@ -78,10 +78,10 @@ namespace SharpLab.Server.Common.Languages {
                 specificDiagnosticOptions: new Dictionary<string, ReportDiagnostic> {
                     // CS1591: Missing XML comment for publicly visible type or member
                     { "CS1591", ReportDiagnostic.Suppress }
-                }
+                },
+                allowUnsafe: true
             );
             options.CSharp.MetadataReferences = _references;
-            options.CSharp.CompilationOptions.WithAllowUnsafe(true);
 
             // ReSharper restore HeapView.ObjectAllocation.Evident
         }

--- a/source/Server/Common/Languages/CSharpAdapter.cs
+++ b/source/Server/Common/Languages/CSharpAdapter.cs
@@ -98,12 +98,11 @@ namespace SharpLab.Server.Common.Languages {
             var outputKind = target != TargetNames.Run
                 ? OutputKind.DynamicallyLinkedLibrary
                 : OutputKind.ConsoleApplication;
-            var allowUnsafe = target != TargetNames.Run;
 
             var project = session.Roslyn.Project;
             var options = ((CSharpCompilationOptions)project.CompilationOptions!);
             session.Roslyn.Project = project.WithCompilationOptions(
-                options.WithOutputKind(outputKind).WithAllowUnsafe(allowUnsafe)
+                options.WithOutputKind(outputKind).WithAllowUnsafe(true)
             );
 
             _topLevelProgramSupport.UpdateOutputKind(session);

--- a/source/Tests/Execution/CompilationTests.cs
+++ b/source/Tests/Execution/CompilationTests.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using SharpLab.Tests.Execution.Internal;
+using SharpLab.Tests.Internal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SharpLab.Tests.Execution {
+    [Collection(TestCollectionNames.Execution)]
+    public class CompilationTests {
+
+        public CompilationTests(ITestOutputHelper output) {
+            TestAssemblyLog.Enable(output);
+        }
+
+        [Theory]
+        [InlineData("UnsafeKeyword.cs")]
+        public async Task Compilation_IsIncludedInOutput(string codeFileName) {
+            // Arrange
+            var code = await TestCode.FromCodeOnlyFileAsync("Compilation/" + codeFileName);
+
+            // Act
+            var output = await ContainerTestDriver.CompileAndExecuteAsync(code);
+
+            // Assert
+            Assert.DoesNotMatch("Exception:", output);
+        }
+    }
+}

--- a/source/Tests/Execution/CompilationTests.cs
+++ b/source/Tests/Execution/CompilationTests.cs
@@ -2,16 +2,10 @@ using System.Threading.Tasks;
 using SharpLab.Tests.Execution.Internal;
 using SharpLab.Tests.Internal;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace SharpLab.Tests.Execution {
     [Collection(TestCollectionNames.Execution)]
     public class CompilationTests {
-
-        public CompilationTests(ITestOutputHelper output) {
-            TestAssemblyLog.Enable(output);
-        }
-
         [Theory]
         [InlineData("UnsafeKeyword.cs")]
         public async Task Compilation_IsIncludedInOutput(string codeFileName) {

--- a/source/Tests/Execution/TestCode/Compilation/UnsafeKeyword.cs
+++ b/source/Tests/Execution/TestCode/Compilation/UnsafeKeyword.cs
@@ -1,0 +1,14 @@
+public static class Program {
+    public static void Main() {
+        unsafe {
+            var node = new Node();
+        }
+    }
+
+    public unsafe struct Node
+    {
+        public int Value;
+        public Node* Left;
+        public Node* Right;
+    }
+}


### PR DESCRIPTION
Changes
- First round work of Issue - #320 to allow `unsafe` keyword in SharpLab run mode.

Known issues
- [ ] Pointers e.g. `int* pointer = &a` will throw a BadImageFormatException